### PR TITLE
Add table of contents to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,15 @@
 # Kiali Design
 
-This repo houses designs for the Kiali project. 
+This repo houses designs for the [Kiali project](https://www.kiali.io/).
+
+## Table of Contents
+1. [Navigation](https://github.com/kiali/kiali-design/blob/master/navigation/design.md)
+  - [Scope Selector](https://github.com/kiali/kiali-design/blob/master/navigation/design.md/#scope-selector)
+  - [Breadcrumbs](https://github.com/kiali/kiali-design/blob/master/navigation/design.md/#breadcrumbs)
+1. [Namespace Overview](https://github.com/kiali/kiali-design/blob/master/namespace-overview/design.md)
+1. [Service Graph](https://github.com/kiali/kiali-design/blob/master/service-graph/design.md)
+  - [Zoom Tool](https://github.com/kiali/kiali-design/blob/master/service-graph/design.md/#zoom-tool)
+  - [Legend](https://github.com/kiali/kiali-design/blob/master/service-graph/design.md/#legend)
+  - [Service Representation Colors](https://github.com/kiali/kiali-design/blob/master/service-graph/design.md/#service-representation-colors)
+1. [Services Page](https://github.com/kiali/kiali-design/blob/master/services/design.md)
+  - [Service Metrics](https://github.com/kiali/kiali-design/blob/master/services/design.md/#metrics)


### PR DESCRIPTION
Adds a table of contents to the readme page.

To avoid an annoying merge conflict, I've added links for currently active PRs into this list as well.